### PR TITLE
Update libevpl and adapt to new APIs; bump devcontainer to Ubuntu 26.04

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ARG ENABLE_XLIO=1
 
@@ -12,25 +12,27 @@ RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
     apt-get -y --no-install-recommends install unminimize && \
     echo y | unminimize && \
-    apt-get -y --no-install-recommends install gcc cmake ninja-build git gdb less psmisc uncrustify libnuma-dev \
-    autoconf automake make libtool pkg-config vim docker.io sudo ncurses-bin libssl-dev openssl clangd npm reuse uthash-dev \
+    apt-get -y --no-install-recommends install gcc cmake ninja-build git gdb less psmisc uncrustify libnuma-dev curl \
+    autoconf automake make libtool pkg-config vim docker.io sudo ncurses-bin libssl-dev openssl clangd reuse uthash-dev \
     net-tools tshark tcpdump uuid-dev iproute2 man-db manpages-dev ca-certificates ssh libjansson-dev libclang-rt-18-dev llvm \
     libxxhash-dev liburcu-dev librdmacm-dev liburing-dev libunwind-dev flex bison libncurses-dev libcurl4-openssl-dev build-essential ruby-full && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    npm install -g @anthropic-ai/claude-code
+    curl -fsSL https://claude.ai/install.sh | bash && \
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 
 
 RUN if [ "$ENABLE_XLIO" = "1" ] ; then \
-    git clone https://github.com/Mellanox/libdpcp.git /libdpcp && \
+    git clone https://github.com/benjarvis/libdpcp.git /libdpcp && \
     cd /libdpcp && \
+    git checkout master-ubuntu26 && \
     ./autogen.sh && \
     ./configure && \
     make -j8 && \
     make install && \
-    git clone https://github.com/benjarvis/libxlio.git /libxlio && \
+    git clone https://github.com/Mellanox/libxlio.git /libxlio && \
     cd /libxlio && \
-    git checkout 3.60.2-nlfix && \
+    git checkout 3.61.2 && \
     ./autogen.sh && \
     ./configure --with-dpcp=/usr/local && \
     make -j8 && \

--- a/.devcontainer/devcontainer.json.license
+++ b/.devcontainer/devcontainer.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2025 Ben Jarvis
-
-SPDX-License-Identifier: Unlicense

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,13 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: flowbench
+Upstream-Contact: Ben Jarvis
+Source: https://github.com/chimera-nas/flowbench
+
+# Config files that cannot carry an inline SPDX header
+Files: .claude/settings.json
+       .devcontainer/devcontainer.json
+       .vscode/settings.json
+       .vscode/tasks.json
+       docs/Gemfile.lock
+Copyright: 2025 Ben Jarvis
+License: Unlicense

--- a/.vscode/settings.json.license
+++ b/.vscode/settings.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2025 Ben Jarvis
-
-SPDX-License-Identifier: Unlicense

--- a/.vscode/tasks.json.license
+++ b/.vscode/tasks.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2025 Ben Jarvis
-
-SPDX-License-Identifier: Unlicense

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_definitions(-fsanitize=address -fno-omit-frame-pointer
                     -fno-optimize-sibling-calls -fstack-protector-all)
     add_link_options(-fsanitize=address)
-endif()    
+    add_definitions(-DEVPL_IOVEC_TRACE=1)
+endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_definitions(-O3)

--- a/docs/Gemfile.lock.license
+++ b/docs/Gemfile.lock.license
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2025 Ben Jarvis
-#
-# SPDX-License-Identifier: Unlicense

--- a/src/framework_evpl.c
+++ b/src/framework_evpl.c
@@ -64,7 +64,7 @@ struct flowbench_evpl_shared {
 void
 close_flow(struct flowbench_evpl_flow *flow)
 {
-    evpl_iovec_release(&flow->iovec);
+    evpl_iovec_release(flow->state->evpl, &flow->iovec);
     if (flow->ping_times) {
         free(flow->ping_times);
     }
@@ -131,6 +131,8 @@ flow_dispatch_callback(
     }
 
     while (can_send(flow)) {
+        struct evpl_iovec send_iov;
+
         if (config->test == FLOWBENCH_TEST_PINGPONG) {
             evpl_get_hf_monotonic_time(evpl, &flow->ping_times[flow->ping_head]);
             flow->ping_slots[flow->ping_head] = 1;
@@ -138,12 +140,12 @@ flow_dispatch_callback(
             flow->inflight_pings++;
         }
 
-        evpl_iovec_addref(&flow->iovec);
+        evpl_iovec_clone(&send_iov, &flow->iovec);
 
         if (shared->connected) {
-            evpl_sendv(evpl, flow->bind, &flow->iovec, 1, config->msg_size, EVPL_SEND_FLAG_TAKE_REF);
+            evpl_sendv(evpl, flow->bind, &send_iov, 1, config->msg_size, EVPL_SEND_FLAG_TAKE_REF);
         } else {
-            evpl_sendtoepv(evpl, flow->bind, shared->remote, &flow->iovec, 1, config->msg_size, EVPL_SEND_FLAG_TAKE_REF)
+            evpl_sendtoepv(evpl, flow->bind, shared->remote, &send_iov, 1, config->msg_size, EVPL_SEND_FLAG_TAKE_REF)
             ;
         }
 
@@ -193,7 +195,7 @@ notify_callback(
 
                 for (i = 0; i < niovecs; ++i) {
                     flowbench_flow_add_recv_bytes(&flow->stats, &now, iovecs[i].length);
-                    evpl_iovec_release(&iovecs[i]);
+                    evpl_iovec_release(evpl, &iovecs[i]);
                 }
 
             } while (niovecs);
@@ -214,18 +216,19 @@ notify_callback(
                     evpl_defer(state->evpl, &flow->dispatch);
 
                 } else {
-                    evpl_iovec_addref(&flow->iovec);
+                    struct evpl_iovec send_iov;
+                    evpl_iovec_clone(&send_iov, &flow->iovec);
                     if (shared->connected) {
-                        evpl_sendv(evpl, flow->bind, &flow->iovec, 1, notify->recv_msg.length, EVPL_SEND_FLAG_TAKE_REF);
+                        evpl_sendv(evpl, flow->bind, &send_iov, 1, notify->recv_msg.length, EVPL_SEND_FLAG_TAKE_REF);
                     } else {
                         evpl_sendtov(evpl, flow->bind, notify->recv_msg.addr,
-                                     &flow->iovec, 1, notify->recv_msg.length, EVPL_SEND_FLAG_TAKE_REF);
+                                     &send_iov, 1, notify->recv_msg.length, EVPL_SEND_FLAG_TAKE_REF);
                     }
                 }
             }
 
             for (i = 0; i < notify->recv_msg.niov; ++i) {
-                evpl_iovec_release(&notify->recv_msg.iovec[i]);
+                evpl_iovec_release(evpl, &notify->recv_msg.iovec[i]);
             }
 
             break;
@@ -269,7 +272,7 @@ create_flow(
         flow->ping_tail      = 0;
     }
 
-    evpl_iovec_alloc(state->evpl, config->msg_size, 4096, 1, &flow->iovec);
+    evpl_iovec_alloc(state->evpl, config->msg_size, 4096, 1, 0, &flow->iovec);
 
     flowbench_add_flow(state->stats, &flow->stats);
 

--- a/src/framework_evpl_rpc2.c
+++ b/src/framework_evpl_rpc2.c
@@ -108,26 +108,30 @@ rpc2_can_send(struct flowbench_evpl_flow *flow)
 
 static void
 rpc2_recv_call_pingpong_callback(
-    struct evpl           *evpl,
-    struct evpl_rpc2_conn *conn,
-    struct Ping           *ping,
-    struct evpl_rpc2_msg  *msg,
-    void                  *private_data)
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct Ping               *ping,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
 {
     struct flowbench_evpl_flow   *flow   = private_data;
     struct flowbench_evpl_state  *state  = flow->state;
     struct flowbench_evpl_shared *shared = state->shared;
     struct Pong                   pong;
+    struct evpl_iovec             reply_iov;
     int                           rc;
 
-    pong.data.iov    = &state->iovec;
-    pong.data.niov   = 1;
-    pong.data.length = state->iovec.length;
-    evpl_iovec_addref(&state->iovec);
+    evpl_rpc2_encoding_take_read_chunk(encoding, NULL, NULL);
+    evpl_iovecs_release(evpl, ping->data.iov, ping->data.niov);
+
+    evpl_iovec_clone(&reply_iov, &state->iovec);
+    xdr_set_ref(&pong, data, &reply_iov, 1, state->iovec.length);
 
     rc = shared->flowbench_program.send_reply_pingpong(state->evpl,
+                                                       NULL,
                                                        &pong,
-                                                       msg);
+                                                       encoding);
 
     if (unlikely(rc)) {
         fprintf(stderr, "Failed to send reply for pingpong: %d\n", rc);
@@ -138,11 +142,12 @@ rpc2_recv_call_pingpong_callback(
 
 static void
 rpc2_recv_call_datagram_callback(
-    struct evpl           *evpl,
-    struct evpl_rpc2_conn *conn,
-    struct Datagram       *request,
-    struct evpl_rpc2_msg  *msg,
-    void                  *private_data)
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct Datagram           *request,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
 {
     struct flowbench_evpl_flow   *flow   = private_data;
     struct flowbench_evpl_state  *state  = flow->state;
@@ -155,8 +160,12 @@ rpc2_recv_call_datagram_callback(
     flowbench_flow_add_recv_bytes(&flow->stats, &now, request->data.length);
     flowbench_flow_add_recv_msgs(&flow->stats, &now, 1);
 
+    evpl_rpc2_encoding_take_read_chunk(encoding, NULL, NULL);
+    evpl_iovecs_release(evpl, request->data.iov, request->data.niov);
+
     rc = shared->flowbench_program.send_reply_datagram(state->evpl,
-                                                       msg);
+                                                       NULL,
+                                                       encoding);
 
     if (unlikely(rc)) {
         fprintf(stderr, "Failed to send reply for datagram: %d\n", rc);
@@ -167,10 +176,11 @@ rpc2_recv_call_datagram_callback(
 
 static void
 rpc2_recv_reply_pingpong_callback(
-    struct evpl *evpl,
-    struct Pong *reply,
-    int          status,
-    void        *private_data)
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct Pong                 *reply,
+    int                          status,
+    void                        *private_data)
 {
     struct flowbench_evpl_flow  *flow  = private_data;
     struct flowbench_evpl_state *state = flow->state;
@@ -191,6 +201,8 @@ rpc2_recv_reply_pingpong_callback(
     flow->inflight_msgs  -= 1;
     flow->inflight_pings--;
 
+    evpl_iovecs_release(evpl, reply->data.iov, reply->data.niov);
+
     if (flow->ping_slots[flow->ping_tail]) {
         flowbench_flow_add_latency(&flow->stats,
                                    ts_interval(&now, &flow->ping_times[flow->ping_tail]));
@@ -205,9 +217,10 @@ rpc2_recv_reply_pingpong_callback(
 
 static void
 rpc2_recv_reply_datagram_callback(
-    struct evpl *evpl,
-    int          status,
-    void        *private_data)
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    int                          status,
+    void                        *private_data)
 {
     struct flowbench_evpl_flow    *flow   = private_data;
     struct flowbench_evpl_state   *state  = flow->state;
@@ -253,20 +266,22 @@ rpc2_flow_dispatch_callback(
     }
 
     while (rpc2_can_send(flow)) {
+        struct evpl_iovec send_iov;
+
+        evpl_iovec_clone(&send_iov, &state->iovec);
+
         if (config->test == FLOWBENCH_TEST_PINGPONG) {
             evpl_get_hf_monotonic_time(evpl, &flow->ping_times[flow->ping_head]);
             flow->ping_slots[flow->ping_head] = 1;
             flow->ping_head                   = (flow->ping_head + 1) & flow->ping_ring_mask;
             flow->inflight_pings++;
 
-            ping.data.iov    = &state->iovec;
-            ping.data.niov   = 1;
-            ping.data.length = config->msg_size;
-            evpl_iovec_addref(&state->iovec);
+            xdr_set_ref(&ping, data, &send_iov, 1, config->msg_size);
 
             shared->flowbench_program.send_call_pingpong(&shared->flowbench_program.rpc2,
                                                          evpl,
                                                          flow->conn,
+                                                         NULL,
                                                          &ping,
                                                          ddp,
                                                          max_write_chunk,
@@ -276,15 +291,12 @@ rpc2_flow_dispatch_callback(
 
         } else {
 
-            datagram.data.iov    = &state->iovec;
-            datagram.data.niov   = 1;
-            datagram.data.length = config->msg_size;
-
-            evpl_iovec_addref(&state->iovec);
+            xdr_set_ref(&datagram, data, &send_iov, 1, config->msg_size);
 
             shared->flowbench_program.send_call_datagram(&shared->flowbench_program.rpc2,
                                                          evpl,
                                                          flow->conn,
+                                                         NULL,
                                                          &datagram,
                                                          1,
                                                          0,
@@ -411,7 +423,7 @@ flowbench_evpl_rpc2_thread_init(
 
     state->evpl = evpl;
 
-    evpl_iovec_alloc(state->evpl, config->msg_size, 4096, 1, &state->iovec);
+    evpl_iovec_alloc(state->evpl, config->msg_size, 4096, 1, 0, &state->iovec);
 
     programs[0] = &shared->flowbench_program.rpc2;
 
@@ -461,7 +473,7 @@ flowbench_evpl_rpc2_thread_destroy(
 
     evpl_rpc2_thread_destroy(state->rpc2_thread);
 
-    evpl_iovec_release(&state->iovec);
+    evpl_iovec_release(evpl, &state->iovec);
 
 
 } /* flowbench_evpl_thread_destroy */


### PR DESCRIPTION
Update libevpl submodule and adjust flowbench for the new iovec / RPC2 APIs:
- evpl_iovec_alloc now takes a flags argument
- evpl_iovec_release takes an evpl handle
- evpl_iovec_addref is replaced by evpl_iovec_clone
- RPC2 recv_call / recv_reply / send_call / send_reply signatures changed to add cred / verf arguments and use evpl_rpc2_encoding
- Receivers now release the iovecs the unmarshaller cloned into the call/reply data, via evpl_rpc2_encoding_take_read_chunk + evpl_iovecs_release.

Define EVPL_IOVEC_TRACE for flowbench TUs in Debug builds so the inline iovec helpers match what libevpl is compiled with; otherwise flowbench falls through the non-trace path and treats canary pointers as real refs, corrupting the canary magic.

Bump the devcontainer base image to Ubuntu 26.04 and update the XLIO / DPCP sources accordingly.